### PR TITLE
Improvement: set the next pomodoro time equal to the last completed one.

### DIFF
--- a/Todoro/AppDelegate.swift
+++ b/Todoro/AppDelegate.swift
@@ -58,7 +58,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
   func splitViewController(_ splitViewController: UISplitViewController, collapseSecondary secondaryViewController:UIViewController, onto primaryViewController:UIViewController) -> Bool {
     guard let secondaryAsNavController = secondaryViewController as? UINavigationController else { return false }
     guard let topAsDetailController = secondaryAsNavController.topViewController as? DetailViewController else { return false }
-    if topAsDetailController.detailItem == nil {
+    if topAsDetailController.task == nil {
       // Return true to indicate that we have handled the collapse by doing nothing; the secondary controller will be discarded.
       return true
     }

--- a/Todoro/DetailViewController.swift
+++ b/Todoro/DetailViewController.swift
@@ -25,7 +25,9 @@ class DetailViewController: UIViewController {
     case taskCompleted
   }
 
-  var detailItem: Task?
+  // MARK: - Properties
+
+  var task: Task?
 
   var currentState: State = .waiting {
     didSet { configureView() }
@@ -70,7 +72,7 @@ class DetailViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    if let task = detailItem {
+    if let task = task {
       navigationItem.title = task.title
 
       currentState = task.isCompleted ? .taskCompleted : .waiting
@@ -82,7 +84,7 @@ class DetailViewController: UIViewController {
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
 
-    if let task = detailItem {
+    if let task = task {
       pomodoroCount = task.pomodoros?.count ?? 0
     }
   }
@@ -121,7 +123,7 @@ class DetailViewController: UIViewController {
   }
 
   @IBAction func markTaskAsCompleted(_ sender: Any) {
-    detailItem?.isCompleted = true
+    task?.isCompleted = true
     (UIApplication.shared.delegate as? AppDelegate)!.saveContext()
     currentState = .taskCompleted
 
@@ -133,7 +135,7 @@ class DetailViewController: UIViewController {
 
   @IBAction func deleteTask(_ sender: Any) {
     guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-          let task = detailItem else {
+          let task = task else {
       return
     }
 
@@ -217,7 +219,7 @@ class DetailViewController: UIViewController {
 
   func savePomodoro() {
     guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
-      let task = detailItem,
+      let task = task,
       let lastTimerTimeInSeconds = lastTimerTimeInSeconds else {
         return
     }

--- a/Todoro/DetailViewController.swift
+++ b/Todoro/DetailViewController.swift
@@ -96,7 +96,7 @@ class DetailViewController: UIViewController {
   }
 
   @IBAction func removeAMinuteToPomodoro(_ sender: Any) {
-    if currentTimeInSeconds >= 1 {
+    if currentTimeInSeconds > Default.oneMinute {
       currentTimeInSeconds -= Default.oneMinute
     }
   }

--- a/Todoro/MasterViewController.swift
+++ b/Todoro/MasterViewController.swift
@@ -87,7 +87,7 @@ class MasterViewController: UITableViewController, NSFetchedResultsControllerDel
       if let indexPath = tableView.indexPathForSelectedRow {
         let object = fetchedResultsController.object(at: indexPath)
         let controller = (segue.destination as! UINavigationController).topViewController as! DetailViewController
-        controller.detailItem = object
+        controller.task = object
         controller.navigationItem.leftBarButtonItem = splitViewController?.displayModeButtonItem
         controller.navigationItem.leftItemsSupplementBackButton = true
       }


### PR DESCRIPTION
Closes #9

Changes:
-------

- Set the current time value for the pomodoro
  if there are pomodoros completed, then the value will be equal to the last
  completed pomodoro.

  If not, it will use the default value.

- Only subtract minutes if the timer has more than 1 minute.

- Rename `detailITem` to `task` in `DetailViewController`.