### PR TITLE
Feature: keep timer running when the app goes to background.

### DIFF
--- a/Todoro.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Todoro.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/Todoro/AppDelegate.swift
+++ b/Todoro/AppDelegate.swift
@@ -26,7 +26,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
     let controller = masterNavigationController.topViewController as! MasterViewController
     controller.managedObjectContext = self.persistentContainer.viewContext
 
-//    application.registerUserNotificationSettings(UIUserNotificationSettings(types: [.alert, .badge, .sound], categories: nil))
     let notificationCenter = UNUserNotificationCenter.current()
     notificationCenter.requestAuthorization(options: [.alert, .sound]) { (granted, error) in
       if granted {
@@ -45,27 +44,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
     // and it begins the transition to the background state.
     // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks.
     // Games should use this method to pause the game.
-    print("")
-    print(#function)
-    print("scheduling local notifications")
-
-    guard CountdownTimer.shared.isActive else {
-      return
-    }
-
-    let content = UNMutableNotificationContent()
-    content.title = "Pomodoro Done"
-    content.body = "Good job"
-
-    content.sound = UNNotificationSound.default()
-    let date = Date(timeIntervalSinceNow: CountdownTimer.shared.timeLeftInSeconds)
-    let triggerDate = Calendar.current.dateComponents([.year,.month,.day,.hour,.minute,.second,], from: date)
-    let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDate, repeats: false)
-
-    // Schedule the notification.
-    let request = UNNotificationRequest(identifier: "pomodoro", content: content, trigger: trigger)
-    let center = UNUserNotificationCenter.current()
-    center.add(request, withCompletionHandler: nil)
   }
 
   func applicationDidEnterBackground(_ application: UIApplication) {
@@ -85,19 +63,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
     // Restart any tasks that were paused (or not yet started) while the application was inactive.
     // If the application was previously in the background, optionally refresh the user interface.
     application.isIdleTimerDisabled = true
-
-    UNUserNotificationCenter.current().getPendingNotificationRequests { (notificationRequests) in
-      notificationRequests.forEach({ (notification) in
-        let trigger = notification.trigger as? UNCalendarNotificationTrigger
-        if let trigger = trigger, let notificationDate = trigger.nextTriggerDate() {
-          let secondsLeft = notificationDate.timeIntervalSinceNow
-          CountdownTimer.shared.prepare(forCountdownInSeconds: secondsLeft)
-          CountdownTimer.shared.startTimer()
-        }
-      })
-    }
-
-    UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: ["pomodoro"])
   }
 
   func applicationWillTerminate(_ application: UIApplication) {
@@ -171,6 +136,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
       }
     }
   }
-
 }
 

--- a/Todoro/AppDelegate.swift
+++ b/Todoro/AppDelegate.swift
@@ -40,19 +40,27 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
   }
 
   func applicationWillResignActive(_ application: UIApplication) {
-    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-    // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+    // Sent when the application is about to move from active to inactive state. This can occur for certain types of
+    // temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application
+    // and it begins the transition to the background state.
+    // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks.
+    // Games should use this method to pause the game.
     print("")
     print(#function)
     print("scheduling local notifications")
+
+    guard CountdownTimer.shared.isActive else {
+      return
+    }
 
     let content = UNMutableNotificationContent()
     content.title = "Pomodoro Done"
     content.body = "Good job"
 
-    // Deliver the notification in five seconds.
     content.sound = UNNotificationSound.default()
-    let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 15, repeats: false)
+    let date = Date(timeIntervalSinceNow: CountdownTimer.shared.timeLeftInSeconds)
+    let triggerDate = Calendar.current.dateComponents([.year,.month,.day,.hour,.minute,.second,], from: date)
+    let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDate, repeats: false)
 
     // Schedule the notification.
     let request = UNNotificationRequest(identifier: "pomodoro", content: content, trigger: trigger)
@@ -61,46 +69,56 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
   }
 
   func applicationDidEnterBackground(_ application: UIApplication) {
-    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+    // Use this method to release shared resources, save user data, invalidate timers, and store enough application
+    // state information to restore your application to its current state in case it is terminated later.
+    // If your application supports background execution,
+    // this method is called instead of applicationWillTerminate: when the user quits.
     application.isIdleTimerDisabled = false
   }
 
   func applicationWillEnterForeground(_ application: UIApplication) {
-    // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
+    // Called as part of the transition from the background to the active state;
+    // here you can undo many of the changes made on entering the background.
   }
 
   func applicationDidBecomeActive(_ application: UIApplication) {
-    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    // Restart any tasks that were paused (or not yet started) while the application was inactive.
+    // If the application was previously in the background, optionally refresh the user interface.
     application.isIdleTimerDisabled = true
 
     UNUserNotificationCenter.current().getPendingNotificationRequests { (notificationRequests) in
-      print(notificationRequests)
       notificationRequests.forEach({ (notification) in
-        print(notification)
-        if let trigger = notification.trigger as? UNTimeIntervalNotificationTrigger {
-          print(trigger.timeInterval)
+        let trigger = notification.trigger as? UNCalendarNotificationTrigger
+        if let trigger = trigger, let notificationDate = trigger.nextTriggerDate() {
+          let secondsLeft = notificationDate.timeIntervalSinceNow
+          CountdownTimer.shared.prepare(forCountdownInSeconds: secondsLeft)
+          CountdownTimer.shared.startTimer()
         }
       })
     }
 
-    print("")
-    print(#function)
-    print("pending notifications canceled")
     UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: ["pomodoro"])
   }
 
   func applicationWillTerminate(_ application: UIApplication) {
-    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    // Called when the application is about to terminate. Save data if appropriate.
+    // See also applicationDidEnterBackground:.
     // Saves changes in the application's managed object context before the application terminates.
     self.saveContext()
   }
 
   // MARK: - Split view
 
-  func splitViewController(_ splitViewController: UISplitViewController, collapseSecondary secondaryViewController:UIViewController, onto primaryViewController:UIViewController) -> Bool {
+  func splitViewController(
+    _ splitViewController: UISplitViewController,
+    collapseSecondary secondaryViewController:UIViewController,
+    onto primaryViewController:UIViewController
+  ) -> Bool {
     guard let secondaryAsNavController = secondaryViewController as? UINavigationController else { return false }
-    guard let topAsDetailController = secondaryAsNavController.topViewController as? DetailViewController else { return false }
+    guard let topAsDetailController = secondaryAsNavController.topViewController as? DetailViewController else {
+      return false
+    }
+
     if topAsDetailController.task == nil {
       // Return true to indicate that we have handled the collapse by doing nothing; the secondary controller will be discarded.
       return true
@@ -120,7 +138,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
     container.loadPersistentStores(completionHandler: { (storeDescription, error) in
       if let error = error as NSError? {
         // Replace this implementation with code to handle the error appropriately.
-        // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+        // fatalError() causes the application to generate a crash log and terminate.
+        // You should not use this function in a shipping application, although it may be useful during development.
 
         /*
          Typical reasons for an error here include:
@@ -145,7 +164,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
         try context.save()
       } catch {
         // Replace this implementation with code to handle the error appropriately.
-        // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+        // fatalError() causes the application to generate a crash log and terminate.
+        // You should not use this function in a shipping application, although it may be useful during development.
         let nserror = error as NSError
         fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
       }

--- a/Todoro/AppDelegate.swift
+++ b/Todoro/AppDelegate.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import CoreData
+import UserNotifications
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDelegate {
@@ -24,12 +25,39 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
     let masterNavigationController = splitViewController.viewControllers[0] as! UINavigationController
     let controller = masterNavigationController.topViewController as! MasterViewController
     controller.managedObjectContext = self.persistentContainer.viewContext
+
+//    application.registerUserNotificationSettings(UIUserNotificationSettings(types: [.alert, .badge, .sound], categories: nil))
+    let notificationCenter = UNUserNotificationCenter.current()
+    notificationCenter.requestAuthorization(options: [.alert, .sound]) { (granted, error) in
+      if granted {
+        print("notifications granted")
+      } else {
+        print("notifications error \(error!.localizedDescription)")
+      }
+    }
+
     return true
   }
 
   func applicationWillResignActive(_ application: UIApplication) {
     // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
     // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+    print("")
+    print(#function)
+    print("scheduling local notifications")
+
+    let content = UNMutableNotificationContent()
+    content.title = "Pomodoro Done"
+    content.body = "Good job"
+
+    // Deliver the notification in five seconds.
+    content.sound = UNNotificationSound.default()
+    let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 15, repeats: false)
+
+    // Schedule the notification.
+    let request = UNNotificationRequest(identifier: "pomodoro", content: content, trigger: trigger)
+    let center = UNUserNotificationCenter.current()
+    center.add(request, withCompletionHandler: nil)
   }
 
   func applicationDidEnterBackground(_ application: UIApplication) {
@@ -45,6 +73,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
   func applicationDidBecomeActive(_ application: UIApplication) {
     // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     application.isIdleTimerDisabled = true
+
+    UNUserNotificationCenter.current().getPendingNotificationRequests { (notificationRequests) in
+      print(notificationRequests)
+      notificationRequests.forEach({ (notification) in
+        print(notification)
+        if let trigger = notification.trigger as? UNTimeIntervalNotificationTrigger {
+          print(trigger.timeInterval)
+        }
+      })
+    }
+
+    print("")
+    print(#function)
+    print("pending notifications canceled")
+    UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: ["pomodoro"])
   }
 
   func applicationWillTerminate(_ application: UIApplication) {

--- a/Todoro/DetailViewController.swift
+++ b/Todoro/DetailViewController.swift
@@ -15,7 +15,7 @@ private extension String {
   static let showCompletedPomodoros = "showCompletedPomodoros"
 }
 
-class DetailViewController: UIViewController, CountdownTimerDelegate, UNUserNotificationCenterDelegate {
+class DetailViewController: UIViewController, CountdownTimerDelegate {
   private struct Default {
     static let oneMinute: Double = 60.0
     static let testTimerInSeconds = oneMinute
@@ -79,8 +79,6 @@ class DetailViewController: UIViewController, CountdownTimerDelegate, UNUserNoti
 
     CountdownTimer.shared.delegate = self
 
-    UNUserNotificationCenter.current().delegate = self
-
     print("DetailsViewController", #function)
 
     if let task = task {
@@ -89,6 +87,26 @@ class DetailViewController: UIViewController, CountdownTimerDelegate, UNUserNoti
     } else {
       configureView()
     }
+
+    let app = UIApplication.shared
+
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(self.applicationWillResignActive(notification:)),
+      name: NSNotification.Name.UIApplicationWillResignActive,
+      object: app
+    )
+
+    NotificationCenter.default.addObserver(
+      self,
+      selector: #selector(self.applicationWillBecomeActive(notification:)),
+      name: NSNotification.Name.UIApplicationDidBecomeActive,
+      object: app
+    )
+  }
+
+  deinit {
+    NotificationCenter.default.removeObserver(self)
   }
 
   override func viewWillAppear(_ animated: Bool) {
@@ -408,4 +426,15 @@ class DetailViewController: UIViewController, CountdownTimerDelegate, UNUserNoti
       print("AVAudioPlayer init failed")
     }
   }
+
+  // MARK: - Observers
+
+  @objc func applicationWillResignActive(notification: Any) {
+    print(#function)
+  }
+
+  @objc func applicationWillBecomeActive(notification: Any) {
+    print(#function)
+  }
+
 }

--- a/Todoro/DetailViewController.swift
+++ b/Todoro/DetailViewController.swift
@@ -465,12 +465,21 @@ class DetailViewController: UIViewController {
     print(#function, "scheduling local notifications")
 
     let content = UNMutableNotificationContent()
-    content.title = "Pomodoro Done"
-    content.body = "Good job"
+
+    switch currentState {
+    case .pomodoroRunning:
+      content.title = "Pomodoro Done"
+      content.body = "Good job"
+    case .breakRunning:
+      content.title = "Break Done"
+      content.body = "Let's back to work"
+    default:
+      preconditionFailure("i should not try to schedule a notification for no timer")
+    }
 
     content.sound = UNNotificationSound.default()
     let date = Date(timeIntervalSinceNow: currentTimeInSeconds)
-    let triggerDate = Calendar.current.dateComponents([.year,.month,.day,.hour,.minute,.second,], from: date)
+    let triggerDate = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
     let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDate, repeats: false)
 
     // Schedule the notification.

--- a/Todoro/DetailViewController.swift
+++ b/Todoro/DetailViewController.swift
@@ -425,20 +425,6 @@ class DetailViewController: UIViewController {
     }
   }
 
-  // MARK: - CountdownTimerDelegate
-
-  func timeUpdated() {
-    updateTimerLabel()
-  }
-
-  func timerDidStop() {
-    if currentState == .pomodoroRunning {
-      completePomodoro()
-    } else {
-      completeBreak()
-    }
-  }
-
   // MARK: - Sounds
 
   fileprivate func playBell() {
@@ -471,6 +457,10 @@ class DetailViewController: UIViewController {
     //  - if pomodoro
     //    - store pomodoro completion for task in "UserDefaults"
     //
+    guard timer != nil else {
+      return
+    }
+
     print("")
     print(#function, "scheduling local notifications")
 


### PR DESCRIPTION
closes #4
closes #5

Changes:
--------

- Serialize pomodoro when going to background.
  So if it’s completed in the background, it will be counted.

- Change notification title if the the timer is for a break.

- Do not schedule notifications if there is no timer running.

- Add observer to check when the app goes to background and back in
  DetailViewController.
  Source: https://stackoverflow.com/a/40316958/611678

- When app goes to background schedule a local notification.
  to be shown when the remainding pomodoro time is due.

  if the application comes back to foreground, it will update the time
  accordingly with the remainder time of the app.

TODO:
-----

- [x] block the back button when the pomodoro is running